### PR TITLE
add missing restored Factory ME Bonus which cause issue on saved jobs

### DIFF
--- a/EveHQ.Prism/Forms/frmBPCalculator.vb
+++ b/EveHQ.Prism/Forms/frmBPCalculator.vb
@@ -467,6 +467,11 @@ Namespace Forms
                 End If
             End If
 
+            ' Restore factory ME bonus
+            If _currentJob.StnMeBonus > 0 Then
+                stnMeBonus.Value = _currentJob.StnMeBonus
+            End If
+
             ' This is a risk, but the Runs property needs to be a long so we can support big runs of capitals.  
             ' But, for the UI, I doubt we will get into 16^2 runs...
             nudRuns.Value = CInt(_currentJob.Runs)


### PR DESCRIPTION
add missing restored Factory ME Bonus which cause issue on saved jobs for ressources values.

Saved values were based on Job object which may have a factory ME, whereas this value were not displayed on the UI.

fix issue #52 