### PR TITLE
[WIP][Prism] Structures preferences

### DIFF
--- a/EveHQ.Prism/Classes/UpwellStructures/Bonus.vb
+++ b/EveHQ.Prism/Classes/UpwellStructures/Bonus.vb
@@ -1,0 +1,670 @@
+﻿Imports EveHQ.EveData
+Imports EveHQ.Prism.BPCalc
+
+Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    ''' <summary>
+    ''' A Structure Bonus Definition
+    ''' </summary>
+    Public Class Bonus
+
+        Private _name As String
+        Private _materialEfficiency As Decimal
+        Private _materialEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+        Private _timeEfficiency As Decimal
+        Private _timeEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+        Private _costEfficiency As Decimal
+        Private _costEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+        Private _jobType As JobType
+        Private _appliesToMarketGroups As HashSet(Of BonusFilter)
+
+        ''' <summary>
+        ''' The Group to which the Bonus should be Applied
+        ''' </summary>
+        Public Property Name As String
+            Get
+                Return _name
+            End Get
+            Set(value As String)
+                _name = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Material Efficiency Rate provided Bonus
+        ''' </summary>
+        Public Property MaterialEfficiency As Decimal
+            Get
+                Return _materialEfficiency
+            End Get
+            Set(value As Decimal)
+                _materialEfficiency = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Material Efficiency Modificators according to System Security Level
+        ''' </summary>
+        ''' <returns></returns>
+        Public ReadOnly Property MaterialEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+            Get
+                Return _materialEfficiencyModificators
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' The Time Efficiency Rate provided Bonus
+        ''' </summary>
+        Public Property TimeEfficiency As Decimal
+            Get
+                Return _timeEfficiency
+            End Get
+            Set(value As Decimal)
+                _timeEfficiency = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Time Efficiency Modificators according to System Security Level
+        ''' </summary>
+        ''' <returns></returns>
+        Public ReadOnly Property TimeEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+            Get
+                Return _timeEfficiencyModificators
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' The Cost Efficiency Rate provided Bonus
+        ''' </summary>
+        Public Property CostEfficiency As Decimal
+            Get
+                Return _costEfficiency
+            End Get
+            Set(value As Decimal)
+                _costEfficiency = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Cost Efficiency Modificators according to System Security Level
+        ''' </summary>
+        ''' <returns></returns>
+        Public ReadOnly Property CostEfficiencyModificators As Dictionary(Of SolarSystemSecurityRange, Decimal)
+            Get
+                Return _costEfficiencyModificators
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Determine to which job type the bonus should be applied
+        ''' This property is binary wide and multiple jobtype can be assigned to the bonus
+        ''' </summary>
+        ''' <returns></returns>
+        Public Property JobType() As JobType
+            Get
+                Return Me._jobType
+            End Get
+            Set(ByVal value As JobType)
+                Me._jobType = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' Determine if the Bonus should be applied to a Science job or a production job
+        ''' </summary>
+        Public ReadOnly Property IsScienceBonus As Boolean
+            Get
+                Return ((JobType.Copying Or JobType.Invention Or JobType.MaterialEfficiencyResearch Or JobType.TimeEfficiencyResearch) = Me._jobType)
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Determine to which Item Market Group ID the bonus is applied
+        ''' http://content.eveonline.com/www/newssystem/media/70592/1/EngineeringRigsv2.jpg
+        ''' </summary>
+        Public ReadOnly Property AppliesToMarketGroups() As HashSet(Of BonusFilter)
+            Get
+                Return _appliesToMarketGroups
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Init a new Structure Bonus with the specified name
+        ''' Set the JobType to All and ME, TE, CE to 0
+        ''' </summary>
+        ''' <param name="name">The name of the structure bonus</param>
+        Public Sub New(name As String)
+            Me.New(name, 0, 0, 0)
+        End Sub
+
+        Public Sub New(name As String, jobType As JobType)
+            Me.New(name, 0, 0, 0, jobType)
+        End Sub
+
+        ''' <summary>
+        ''' Init a new Structure Bonus with the specified name, ME, TE and CE
+        ''' Set the JobType to All
+        ''' </summary>
+        ''' <param name="name"></param>
+        ''' <param name="materialEfficiency"></param>
+        ''' <param name="timeEfficiency"></param>
+        ''' <param name="costEfficiency"></param>
+        Public Sub New(name As String, materialEfficiency As Decimal, timeEfficiency As Decimal, costEfficiency As Decimal)
+            Me.New(name, materialEfficiency, timeEfficiency, costEfficiency, (JobType.Copying And JobType.Invention And JobType.Manufacturing And JobType.MaterialEfficiencyResearch And JobType.TimeEfficiencyResearch))
+        End Sub
+
+        ''' <summary>
+        ''' Init a new Structure Bonus with the specified name, ME, TE, CE and JobType
+        ''' </summary>
+        ''' <param name="name"></param>
+        ''' <param name="materialEfficiency"></param>
+        ''' <param name="timeEfficiency"></param>
+        ''' <param name="costEfficiency"></param>
+        ''' <param name="jobType"></param>
+        Public Sub New(name As String, materialEfficiency As Decimal, timeEfficiency As Decimal, costEfficiency As Decimal, jobType As JobType)
+
+            Me._appliesToMarketGroups = New HashSet(Of BonusFilter)
+            Me._materialEfficiencyModificators = New Dictionary(Of SolarSystemSecurityRange, Decimal)
+            Me._timeEfficiencyModificators = New Dictionary(Of SolarSystemSecurityRange, Decimal)
+            Me._costEfficiencyModificators = New Dictionary(Of SolarSystemSecurityRange, Decimal)
+
+            Me._name = name
+            Me._materialEfficiency = materialEfficiency
+            Me._timeEfficiency = timeEfficiency
+            Me._costEfficiency = _costEfficiency
+            Me._jobType = jobType
+
+        End Sub
+
+        ''' <summary>
+        ''' Return the ME value for the specified Solar System
+        ''' </summary>
+        ''' <param name="solarSystem"></param>
+        ''' <returns></returns>
+        Public Function GetMaterialEfficiency(solarSystem As SolarSystem) As Decimal
+            Select Case solarSystem.Security
+                Case >= 5
+                    Return Me.GetMaterialEfficiency(SolarSystemSecurityRange.High)
+                Case > 0
+                    Return Me.GetMaterialEfficiency(SolarSystemSecurityRange.Low)
+                Case Else
+                    Return Me.GetMaterialEfficiency(SolarSystemSecurityRange.Null)
+            End Select
+        End Function
+
+        ''' <summary>
+        ''' Return the ME value for the specified solar system security level
+        ''' </summary>
+        ''' <param name="security"></param>
+        ''' <returns></returns>
+        Public Function GetMaterialEfficiency(security As SolarSystemSecurityRange) As Decimal
+            If Me._materialEfficiencyModificators.ContainsKey(security) Then
+                Return Me._materialEfficiency * Me._materialEfficiencyModificators(security)
+            End If
+
+            Return Me._materialEfficiency
+        End Function
+
+        ''' <summary>
+        ''' Return the TE value for the specified Solar System
+        ''' </summary>
+        ''' <param name="solarSystem"></param>
+        ''' <returns></returns>
+        Public Function GetTimeEfficiency(solarSystem As SolarSystem) As Decimal
+            Select Case solarSystem.Security
+                Case >= 5
+                    Return Me.GetTimeEfficiency(SolarSystemSecurityRange.High)
+                Case > 0
+                    Return Me.GetTimeEfficiency(SolarSystemSecurityRange.Low)
+                Case Else
+                    Return Me.GetTimeEfficiency(SolarSystemSecurityRange.Null)
+            End Select
+        End Function
+
+        ''' <summary>
+        ''' Return the TE value for the specified solar system security level
+        ''' </summary>
+        ''' <param name="security"></param>
+        ''' <returns></returns>
+        Public Function GetTimeEfficiency(security As SolarSystemSecurityRange) As Decimal
+            If Me._timeEfficiencyModificators.ContainsKey(security) Then
+                Return Me._timeEfficiency * Me._timeEfficiencyModificators(security)
+            End If
+
+            Return Me._timeEfficiency
+        End Function
+
+        ''' <summary>
+        ''' Return the CE value for the specified Solar System
+        ''' </summary>
+        ''' <param name="solarSystem"></param>
+        ''' <returns></returns>
+        Public Function GetCostEfficiency(solarSystem As SolarSystem) As Decimal
+            Select Case solarSystem.Security
+                Case >= 5
+                    Return Me.GetCostEfficiency(SolarSystemSecurityRange.High)
+                Case > 0
+                    Return Me.GetCostEfficiency(SolarSystemSecurityRange.Low)
+                Case Else
+                    Return Me.GetCostEfficiency(SolarSystemSecurityRange.Null)
+            End Select
+        End Function
+
+        ''' <summary>
+        ''' Return the CE value for the specified solar system security level
+        ''' </summary>
+        ''' <param name="security"></param>
+        ''' <returns></returns>
+        Public Function GetCostEfficiency(security As SolarSystemSecurityRange) As Decimal
+            If Me._costEfficiencyModificators.ContainsKey(security) Then
+                Return Me._costEfficiency * Me._costEfficiencyModificators(security)
+            End If
+
+            Return Me._costEfficiency
+        End Function
+
+        ''' <summary>
+        ''' Check if the structure bonus should be applied to the job
+        ''' </summary>
+        ''' <param name="job">The Job which should be checked</param>
+        ''' <returns></returns>
+        Public Function IsAppliedTo(job As Job) As Boolean
+
+            ' Check if the job is an invention job, therefore, apply bitwise operation on the bonus job type
+            If job.HasInventionJob Then
+
+                Return ((Me._jobType And JobType.Invention) = JobType.Invention)
+
+            End If
+
+            ' Check if the job is an ME job, therefore, apply bitwise operation on the bonus job type
+            If Not String.IsNullOrEmpty(job.OverridingME) Then
+
+                Return ((Me._jobType And JobType.MaterialEfficiencyResearch) = JobType.MaterialEfficiencyResearch)
+
+            End If
+
+            ' Check if the job is a TE job, therefore, apply bitwise operation on the bonus job type
+            If Not String.IsNullOrEmpty(job.OverridingPE) Then
+
+                Return ((Me._jobType And JobType.TimeEfficiencyResearch) = JobType.TimeEfficiencyResearch)
+
+            End If
+
+            Return Me.IsAppliedTo(StaticData.Types(job.CurrentBlueprint.ProductId))
+
+        End Function
+
+        ''' <summary>
+        ''' Search in the bonus array if we found the EveType Market Group ID for the associated Tech Level
+        ''' </summary>
+        ''' <param name="type">The EveType which should be checked</param>
+        ''' <returns></returns>
+        Public Function IsAppliedTo(type As EveType) As Boolean
+
+            Dim techLevel As Double = StaticData.GetAttributeDataForItem(type.Id).  ' Fetch item attributes for tech level (422)
+                      Values.
+                      Where(Function(a) a.Id.Equals(422)).
+                      Select(Function(a) a.Value).
+                      FirstOrDefault()
+
+            Return (From group In Me._appliesToMarketGroups
+                    Where group.MarketGroupId = type.MarketGroupId
+                    Where group.TechnologyLevel = techLevel Or group.TechnologyLevel = 0).Any()
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/Faction Frigates, Destroyers and Shuttles
+        ''' </summary>
+        Public Function ApplyToT1SmallShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 5 Or marketGroup.ParentGroupId = 1362 Or
+                                 marketGroup.ParentGroupId = 464 Or marketGroup.ParentGroupId = 391 Or
+                                 marketGroup.ParentGroupId = 1815)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 1)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T2 Frigates and Destroyers
+        ''' </summary>
+        Public Function ApplyToT2SmallShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 432 Or marketGroup.ParentGroupId = 420 Or
+                                 marketGroup.ParentGroupId = 1065 Or marketGroup.ParentGroupId = 399 Or
+                                 marketGroup.ParentGroupId = 2146 Or marketGroup.ParentGroupId = 2125 Or
+                                 marketGroup.ParentGroupId = 823)
+                                             Select marketGroup.Id).ToArray()
+
+            marketGroups = marketGroups.Union({1924}).ToArray()
+
+            Return Me.Apply(marketGroups, 2)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T3 Destroyers
+        ''' </summary>
+        Public Function ApplyToT3SmallShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where marketGroup.ParentGroupId = 1951
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 3)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/Faction Cruisers, Battlecruisers, Industrial Ships and Mining Barges
+        ''' </summary>
+        Public Function ApplyToT1MediumShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 6 Or marketGroup.ParentGroupId = 8 Or
+                                 marketGroup.ParentGroupId = 1369 Or marketGroup.ParentGroupId = 469 Or
+                                 marketGroup.ParentGroupId = 1703)
+                                             Select marketGroup.Id).ToArray()
+
+            marketGroups = marketGroups.Union({494}).ToArray()
+
+            Return Me.Apply(marketGroups, 1)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T2 Cruisers, Battlecruisers, Haulers and Exhumers
+        ''' </summary>
+        Public Function ApplyToT2MediumShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 437 Or marketGroup.ParentGroupId = 448 Or
+                                 marketGroup.ParentGroupId = 1070 Or marketGroup.ParentGroupId = 822 Or
+                                 marketGroup.ParentGroupId = 824 Or marketGroup.ParentGroupId = 829)
+                                             Select marketGroup.Id).ToArray()
+
+            marketGroups = marketGroups.Union({874}).ToArray()
+
+            Return Me.Apply(marketGroups, 2)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T3 Cruisers and subsystems
+        ''' </summary>
+        Public Function ApplyToT3MediumShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 1610 Or marketGroup.ParentGroupId = 1625 Or
+                                 marketGroup.ParentGroupId = 1627 Or marketGroup.ParentGroupId = 1626 Or
+                                 marketGroup.ParentGroupId = 1138)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 3)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/Factions Battleships, Freighters and Industrial Command Ships
+        ''' </summary>
+        Public Function ApplyToT1LargeShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 7 Or marketGroup.ParentGroupId = 1378 Or
+                                 marketGroup.ParentGroupId = 766 Or marketGroup.ParentGroupId = 2335)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 1)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T2 Battleships, Freighters
+        ''' </summary>
+        Public Function ApplyToT2LargeShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 1075 Or marketGroup.ParentGroupId = 1089 Or
+                                 marketGroup.ParentGroupId = 1080)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 2)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/Faction Capitals
+        ''' </summary>
+        Public Function ApplyToT1CapitalShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 817 Or marketGroup.ParentGroupId = 761 Or
+                                 marketGroup.ParentGroupId = 2271)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 1)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/Faction Super Capitals
+        ''' </summary>
+        Public Function ApplyToT1SuperCapitalShips() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where marketGroup.ParentGroupId = 812 Or marketGroup.ParentGroupId = 817
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 1)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/T2/Faction Drones and Fighters
+        ''' </summary>
+        Public Function ApplyToDrones() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 159 Or marketGroup.ParentGroupId = 2236)
+                                             Select marketGroup.Id).ToArray()
+
+            marketGroups = marketGroups.Union({158, 841, 842, 843, 1646}).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1/T2/Faction Charges
+        ''' </summary>
+        Public Function ApplyToCharges() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 2297 Or marketGroup.ParentGroupId = 852 Or
+                                 marketGroup.ParentGroupId = 853 Or marketGroup.ParentGroupId = 994 Or
+                                 marketGroup.ParentGroupId = 851 Or marketGroup.ParentGroupId = 848 Or
+                                 marketGroup.ParentGroupId = 990 Or marketGroup.ParentGroupId = 849 Or
+                                 marketGroup.ParentGroupId = 850 Or marketGroup.ParentGroupId = 115 Or
+                                 marketGroup.ParentGroupId = 580 Or marketGroup.ParentGroupId = 968 Or
+                                 marketGroup.ParentGroupId = 581 Or marketGroup.ParentGroupId = 117 Or
+                                 marketGroup.ParentGroupId = 118 Or marketGroup.ParentGroupId = 387 Or
+                                 marketGroup.ParentGroupId = 1316 Or marketGroup.ParentGroupId = 505 Or
+                                 marketGroup.ParentGroupId = 120 Or marketGroup.ParentGroupId = 846 Or
+                                 marketGroup.ParentGroupId = 847 Or marketGroup.ParentGroupId = 986 Or
+                                 marketGroup.ParentGroupId = 845)
+                                             Select marketGroup.Id).ToArray()
+
+            marketGroups = marketGroups.Union({116, 2197, 2196, 1015, 139, 593, 1103, 1094, 2198}).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T1 Capital Construction Components
+        ''' </summary>
+        Public Function ApplyToT1CapConstComponents() As Bonus
+
+            Dim marketGroups As Integer() = {781}
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T2 Capital Construction Components
+        ''' </summary>
+        Public Function ApplyToT2CapConstComponents() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where marketGroup.ParentGroupId = 1883
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T2 Construction Components
+        ''' </summary>
+        Public Function ApplyToT2ConstComponents() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where marketGroup.ParentGroupId = 65
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with T3 Construction Components
+        ''' </summary>
+        Public Function ApplyToT3ConstComponents() As Bonus
+
+            Dim marketGroups As Integer() = {1147}
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Structure Components
+        ''' </summary>
+        Public Function ApplyToStructureComponents() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where marketGroup.ParentGroupId = 1021
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Structure Modifications
+        ''' </summary>
+        Public Function ApplyToStructureModifications() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 2205 Or marketGroup.ParentGroupId = 2340 Or
+                                 marketGroup.ParentGroupId = 2204)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Structure Equipments
+        ''' </summary>
+        Public Function ApplyToStructureEquipments() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 2206 Or marketGroup.ParentGroupId = 2207 Or
+                                 marketGroup.ParentGroupId = 2208 Or marketGroup.ParentGroupId = 2210 Or
+                                 marketGroup.ParentGroupId = 2209 Or marketGroup.ParentGroupId = 2227 Or
+                                 marketGroup.ParentGroupId = 2226)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Upwell Structure
+        ''' </summary>
+        Public Function ApplyToUpwellStructure() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 2199 Or marketGroup.ParentGroupId = 2324)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Starbase Structure
+        ''' </summary>
+        Public Function ApplyToStarbaseStructure() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 1285 Or marketGroup.ParentGroupId = 2324 Or
+                                 marketGroup.ParentGroupId = 1534)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Fuel Blocks
+        ''' </summary>
+        Public Function ApplyToFuelBlocks() As Bonus
+
+            Dim marketGroups As Integer() = {1870}
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with Deployable Structure
+        ''' </summary>
+        Public Function ApplyToDeployableStructure() As Bonus
+
+            Dim marketGroups As Integer() = (From marketGroup In StaticData.MarketGroups.Values
+                                             Where (marketGroup.ParentGroupId = 404 Or marketGroup.ParentGroupId = 379)
+                                             Select marketGroup.Id).ToArray()
+
+            Return Me.Apply(marketGroups, 0)
+
+        End Function
+
+        ''' <summary>
+        ''' Seeds bonus array with specifieds marketGroups for specified tech level
+        ''' </summary>
+        ''' <param name="marketGroups">The market groups with which bonus array should be seeded</param>
+        ''' <param name="techLevel">The tech level for which bonus will be seeded</param>
+        Private Function Apply(marketGroups As Integer(), techLevel As Integer) As Bonus
+
+            For Each marketGroup As Integer In marketGroups
+
+                Me._appliesToMarketGroups.Add(New BonusFilter(marketGroup, techLevel))
+
+            Next
+
+            Return Me
+
+        End Function
+
+    End Class
+
+End Namespace

--- a/EveHQ.Prism/Classes/UpwellStructures/BonusFilter.vb
+++ b/EveHQ.Prism/Classes/UpwellStructures/BonusFilter.vb
@@ -1,0 +1,43 @@
+﻿Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    Public Class BonusFilter
+
+        Private _marketGroupId As Integer
+        Private _technologyLevel As Integer
+
+        ''' <summary>
+        ''' The Market Group ID to which filter is related
+        ''' </summary>
+        ''' <returns></returns>
+        Public Property MarketGroupId() As Integer
+            Get
+                Return _marketGroupId
+            End Get
+            Set(ByVal value As Integer)
+                _marketGroupId = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Technology Level to which filter should be applied
+        ''' </summary>
+        ''' <returns></returns>
+        Public Property TechnologyLevel() As Integer
+            Get
+                Return _technologyLevel
+            End Get
+            Set(ByVal value As Integer)
+                _technologyLevel = value
+            End Set
+        End Property
+
+        Public Sub New(marketGroupId As Integer, technologyLevel As Integer)
+
+            Me._marketGroupId = marketGroupId
+            Me._technologyLevel = technologyLevel
+
+        End Sub
+
+    End Class
+
+End Namespace

--- a/EveHQ.Prism/Classes/UpwellStructures/JobType.vb
+++ b/EveHQ.Prism/Classes/UpwellStructures/JobType.vb
@@ -1,0 +1,14 @@
+﻿Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    <Flags>
+    Public Enum JobType As Integer
+
+        Manufacturing = 1
+        Invention = 2
+        Copying = 4
+        MaterialEfficiencyResearch = 8
+        TimeEfficiencyResearch = 16
+
+    End Enum
+
+End Namespace

--- a/EveHQ.Prism/Classes/UpwellStructures/SolarSystemSecurityRange.vb
+++ b/EveHQ.Prism/Classes/UpwellStructures/SolarSystemSecurityRange.vb
@@ -1,0 +1,11 @@
+﻿Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    Public Enum SolarSystemSecurityRange
+
+        Null
+        Low
+        High
+
+    End Enum
+
+End Namespace

--- a/EveHQ.Prism/Classes/UpwellStructures/UpwellStructure.vb
+++ b/EveHQ.Prism/Classes/UpwellStructures/UpwellStructure.vb
@@ -1,0 +1,78 @@
+﻿Imports EveHQ.EveData
+
+Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    ''' <summary>
+    ''' A Structure Definition
+    ''' </summary>
+    Public Class UpwellStructure
+
+        Private _name As String
+        Private _itemType As EveType
+        Private _location As SolarSystem
+        Private _bonuses As List(Of Bonus)
+
+        ''' <summary>
+        ''' The Name of the Structure
+        ''' </summary>
+        Public Property Name() As String
+            Get
+                Return _name
+            End Get
+            Set(value As String)
+                _name = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Type of the Structure
+        ''' </summary>
+        Public Property ItemType() As EveType
+            Get
+                Return _itemType
+            End Get
+            Set(ByVal value As EveType)
+                _itemType = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' The Solar System where the Structure is located
+        ''' </summary>
+        Public Property Location() As SolarSystem
+            Get
+                Return _location
+            End Get
+            Set(value As SolarSystem)
+                _location = value
+            End Set
+        End Property
+
+        ''' <summary>
+        ''' A list of bonuses which will be applied to the structure for manufacturing jobs
+        ''' </summary>
+        Public ReadOnly Property ManufacturingBonuses As List(Of Bonus)
+            Get
+                Return _bonuses.Where(Function(b) Not b.IsScienceBonus).ToList()
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' A list of bonuses which will be applied to the structure for science jobs (Invention, ME/TE Research, Copy)
+        ''' </summary>
+        Public ReadOnly Property ScienceBonuses As List(Of Bonus)
+            Get
+                Return _bonuses.Where(Function(b) b.IsScienceBonus).ToList()
+            End Get
+        End Property
+
+        Public Sub New()
+
+            Me.Name = ""
+            Me._bonuses = New List(Of Bonus)
+
+        End Sub
+
+    End Class
+
+End Namespace

--- a/EveHQ.Prism/EveHQ.Prism.vbproj
+++ b/EveHQ.Prism/EveHQ.Prism.vbproj
@@ -136,6 +136,17 @@
     <Compile Include="BPCalc\OwnedBlueprint.vb" />
     <Compile Include="BPCalc\SwapResource.vb" />
     <Compile Include="Classes\BlueprintAsset.vb" />
+    <Compile Include="Classes\UpwellStructures\JobType.vb" />
+    <Compile Include="Classes\UpwellStructures\Bonus.vb" />
+    <Compile Include="Classes\UpwellStructures\BonusFilter.vb" />
+    <Compile Include="Classes\UpwellStructures\UpwellStructure.vb" />
+    <Compile Include="Classes\UpwellStructures\SolarSystemSecurityRange.vb" />
+    <Compile Include="Forms\frmUpwellStructure.Designer.vb">
+      <DependentUpon>frmUpwellStructure.vb</DependentUpon>
+    </Compile>
+    <Compile Include="Forms\frmUpwellStructure.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="My Project\AssemblyInfo.vb" />
     <Compile Include="_Deprecated\BPCCostInfo.vb" />
     <Compile Include="Classes\BlueprintCopyCostInfo.vb" />
@@ -372,6 +383,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\frmSelectQuantity.resx">
       <DependentUpon>frmSelectQuantity.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\frmUpwellStructure.resx">
+      <DependentUpon>frmUpwellStructure.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="My Project\Resources.resx">
       <Generator>VbMyResourcesResXFileCodeGenerator</Generator>

--- a/EveHQ.Prism/Forms/frmBPCalculator.Designer.vb
+++ b/EveHQ.Prism/Forms/frmBPCalculator.Designer.vb
@@ -2367,6 +2367,20 @@ Namespace Forms
             Me.btnSaveProductionJobAs.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled
             Me.btnSaveProductionJobAs.TabIndex = 185
             Me.btnSaveProductionJobAs.Text = "Save Job As..."
+
+            '
+            ' DEBUG !
+            '
+            Me.btnEditStructurePreference = New DevComponents.DotNetBar.ButtonX()
+            Me.btnEditStructurePreference.AccessibleRole = System.Windows.Forms.AccessibleRole.PushButton
+            Me.btnEditStructurePreference.ColorTable = DevComponents.DotNetBar.eButtonColor.OrangeWithBackground
+            Me.btnEditStructurePreference.Location = New System.Drawing.Point(759, 150)
+            Me.btnEditStructurePreference.Name = "btnDebug"
+            Me.btnEditStructurePreference.Size = New System.Drawing.Size(56, 56)
+            Me.btnEditStructurePreference.Style = DevComponents.DotNetBar.eDotNetBarStyle.StyleManagerControlled
+            Me.btnEditStructurePreference.Text = "DEBUG"
+            Me.PanelEx1.Controls.Add(Me.btnEditStructurePreference)
+
             '
             'nudMELevel
             '
@@ -2720,6 +2734,11 @@ Namespace Forms
         Friend WithEvents SaveJobDialogCheckBox As DevComponents.DotNetBar.Command
         Friend WithEvents stnMeBonus As DevComponents.Editors.IntegerInput
         Friend WithEvents Label1 As System.Windows.Forms.Label
+
+        '
+        ' DEBUG !!!!
+        '
+        Friend WithEvents btnEditStructurePreference As DevComponents.DotNetBar.ButtonX
 
     End Class
 End NameSpace

--- a/EveHQ.Prism/Forms/frmBPCalculator.vb
+++ b/EveHQ.Prism/Forms/frmBPCalculator.vb
@@ -1765,6 +1765,14 @@ Namespace Forms
             End If
 
         End Sub
+
+        '
+        ' DEBUG !!!!
+        '
+        Private Sub btnEditStructurePreference_Click(ByVal sender As Object, ByVal e As EventArgs) Handles btnEditStructurePreference.Click
+            Dim formStructurePreference As EveHQ.Plugins.Prism.UpwellStructures.frmUpwellStructure = New EveHQ.Plugins.Prism.UpwellStructures.frmUpwellStructure()
+            formStructurePreference.Show()
+        End Sub
     End Class
 
     Public Enum BPCalcStartMode

--- a/EveHQ.Prism/Forms/frmUpwellStructure.Designer.vb
+++ b/EveHQ.Prism/Forms/frmUpwellStructure.Designer.vb
@@ -1,0 +1,477 @@
+﻿Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    <Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+    Partial Class frmUpwellStructure
+        Inherits System.Windows.Forms.Form
+
+        'Form remplace la méthode Dispose pour nettoyer la liste des composants.
+        <System.Diagnostics.DebuggerNonUserCode()>
+        Protected Overrides Sub Dispose(ByVal disposing As Boolean)
+            Try
+                If disposing AndAlso components IsNot Nothing Then
+                    components.Dispose()
+                End If
+            Finally
+                MyBase.Dispose(disposing)
+            End Try
+        End Sub
+
+        'Requise par le Concepteur Windows Form
+        Private components As System.ComponentModel.IContainer
+
+        'REMARQUE : la procédure suivante est requise par le Concepteur Windows Form
+        'Elle peut être modifiée à l'aide du Concepteur Windows Form.  
+        'Ne la modifiez pas à l'aide de l'éditeur de code.
+        <System.Diagnostics.DebuggerStepThrough()>
+        Private Sub InitializeComponent()
+            Me.pnlStructDefinition = New System.Windows.Forms.Panel()
+            Me.cbxStructLocation = New System.Windows.Forms.ComboBox()
+            Me.cbxStructType = New System.Windows.Forms.ComboBox()
+            Me.tfStructName = New System.Windows.Forms.TextBox()
+            Me.lblStructLocation = New System.Windows.Forms.Label()
+            Me.lblStructType = New System.Windows.Forms.Label()
+            Me.lblStructName = New System.Windows.Forms.Label()
+            Me.gpxStructProdBonuses = New System.Windows.Forms.GroupBox()
+            Me.lblStructProdBonus_TimEff = New System.Windows.Forms.Label()
+            Me.lblStructProdBonus_MatEff = New System.Windows.Forms.Label()
+            Me.cbxStructProdBonus_TimEff_3 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_TimEff_2 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_TimEff_1 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_MatEff_3 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_MatEff_2 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_MatEff_1 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_Group_3 = New System.Windows.Forms.ComboBox()
+            Me.lblItemGroup = New System.Windows.Forms.Label()
+            Me.cbxStructProdBonus_Group_2 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructProdBonus_Group_1 = New System.Windows.Forms.ComboBox()
+            Me.gpxStructScienceBonuses = New System.Windows.Forms.GroupBox()
+            Me.lblStructScieBonus_TimEff = New System.Windows.Forms.Label()
+            Me.cbxStructScieBonus_Group_1 = New System.Windows.Forms.ComboBox()
+            Me.lblStructScieBonus_CosEff = New System.Windows.Forms.Label()
+            Me.cbxStructScieBonus_Group_2 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_TimEff_3 = New System.Windows.Forms.ComboBox()
+            Me.lblScienceJobType = New System.Windows.Forms.Label()
+            Me.cbxStructScieBonus_TimEff_2 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_Group_3 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_TimEff_1 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_CosEff_1 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_CosEff_3 = New System.Windows.Forms.ComboBox()
+            Me.cbxStructScieBonus_CosEff_2 = New System.Windows.Forms.ComboBox()
+            Me.btnCancel = New System.Windows.Forms.Button()
+            Me.btnSave = New System.Windows.Forms.Button()
+            Me.pnlStructDefinition.SuspendLayout()
+            Me.gpxStructProdBonuses.SuspendLayout()
+            Me.gpxStructScienceBonuses.SuspendLayout()
+            Me.SuspendLayout()
+            '
+            'pnlStructDefinition
+            '
+            Me.pnlStructDefinition.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.pnlStructDefinition.Controls.Add(Me.cbxStructLocation)
+            Me.pnlStructDefinition.Controls.Add(Me.cbxStructType)
+            Me.pnlStructDefinition.Controls.Add(Me.tfStructName)
+            Me.pnlStructDefinition.Controls.Add(Me.lblStructLocation)
+            Me.pnlStructDefinition.Controls.Add(Me.lblStructType)
+            Me.pnlStructDefinition.Controls.Add(Me.lblStructName)
+            Me.pnlStructDefinition.Location = New System.Drawing.Point(12, 12)
+            Me.pnlStructDefinition.Name = "pnlStructDefinition"
+            Me.pnlStructDefinition.Size = New System.Drawing.Size(290, 78)
+            Me.pnlStructDefinition.TabIndex = 0
+            '
+            'cbxStructLocation
+            '
+            Me.cbxStructLocation.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.cbxStructLocation.FormattingEnabled = True
+            Me.cbxStructLocation.Location = New System.Drawing.Point(89, 52)
+            Me.cbxStructLocation.Name = "cbxStructLocation"
+            Me.cbxStructLocation.Size = New System.Drawing.Size(198, 21)
+            Me.cbxStructLocation.TabIndex = 1
+            '
+            'cbxStructType
+            '
+            Me.cbxStructType.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.cbxStructType.FormattingEnabled = True
+            Me.cbxStructType.Location = New System.Drawing.Point(89, 27)
+            Me.cbxStructType.Name = "cbxStructType"
+            Me.cbxStructType.Size = New System.Drawing.Size(198, 21)
+            Me.cbxStructType.TabIndex = 1
+            '
+            'tfStructName
+            '
+            Me.tfStructName.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.tfStructName.Location = New System.Drawing.Point(89, 2)
+            Me.tfStructName.Name = "tfStructName"
+            Me.tfStructName.Size = New System.Drawing.Size(198, 20)
+            Me.tfStructName.TabIndex = 1
+            '
+            'lblStructLocation
+            '
+            Me.lblStructLocation.AutoSize = True
+            Me.lblStructLocation.Location = New System.Drawing.Point(3, 55)
+            Me.lblStructLocation.Name = "lblStructLocation"
+            Me.lblStructLocation.Size = New System.Drawing.Size(54, 13)
+            Me.lblStructLocation.TabIndex = 1
+            Me.lblStructLocation.Text = "Location :"
+            '
+            'lblStructType
+            '
+            Me.lblStructType.AutoSize = True
+            Me.lblStructType.Location = New System.Drawing.Point(3, 30)
+            Me.lblStructType.Name = "lblStructType"
+            Me.lblStructType.Size = New System.Drawing.Size(37, 13)
+            Me.lblStructType.TabIndex = 1
+            Me.lblStructType.Text = "Type :"
+            '
+            'lblStructName
+            '
+            Me.lblStructName.AutoSize = True
+            Me.lblStructName.Location = New System.Drawing.Point(3, 5)
+            Me.lblStructName.Name = "lblStructName"
+            Me.lblStructName.Size = New System.Drawing.Size(41, 13)
+            Me.lblStructName.TabIndex = 1
+            Me.lblStructName.Text = "Name :"
+            '
+            'gpxStructProdBonuses
+            '
+            Me.gpxStructProdBonuses.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.gpxStructProdBonuses.Controls.Add(Me.lblStructProdBonus_TimEff)
+            Me.gpxStructProdBonuses.Controls.Add(Me.lblStructProdBonus_MatEff)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_TimEff_3)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_TimEff_2)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_TimEff_1)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_MatEff_3)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_MatEff_2)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_MatEff_1)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_Group_3)
+            Me.gpxStructProdBonuses.Controls.Add(Me.lblItemGroup)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_Group_2)
+            Me.gpxStructProdBonuses.Controls.Add(Me.cbxStructProdBonus_Group_1)
+            Me.gpxStructProdBonuses.Location = New System.Drawing.Point(12, 96)
+            Me.gpxStructProdBonuses.Name = "gpxStructProdBonuses"
+            Me.gpxStructProdBonuses.Size = New System.Drawing.Size(290, 121)
+            Me.gpxStructProdBonuses.TabIndex = 1
+            Me.gpxStructProdBonuses.TabStop = False
+            Me.gpxStructProdBonuses.Text = "Manufacturing Jobs Bonuses from Rigs"
+            '
+            'lblStructProdBonus_TimEff
+            '
+            Me.lblStructProdBonus_TimEff.AutoSize = True
+            Me.lblStructProdBonus_TimEff.Location = New System.Drawing.Point(219, 18)
+            Me.lblStructProdBonus_TimEff.Name = "lblStructProdBonus_TimEff"
+            Me.lblStructProdBonus_TimEff.Size = New System.Drawing.Size(54, 13)
+            Me.lblStructProdBonus_TimEff.TabIndex = 0
+            Me.lblStructProdBonus_TimEff.Text = "TE Bonus"
+            '
+            'lblStructProdBonus_MatEff
+            '
+            Me.lblStructProdBonus_MatEff.AutoSize = True
+            Me.lblStructProdBonus_MatEff.Location = New System.Drawing.Point(157, 18)
+            Me.lblStructProdBonus_MatEff.Name = "lblStructProdBonus_MatEff"
+            Me.lblStructProdBonus_MatEff.Size = New System.Drawing.Size(56, 13)
+            Me.lblStructProdBonus_MatEff.TabIndex = 0
+            Me.lblStructProdBonus_MatEff.Text = "ME Bonus"
+            '
+            'cbxStructProdBonus_TimEff_3
+            '
+            Me.cbxStructProdBonus_TimEff_3.Enabled = False
+            Me.cbxStructProdBonus_TimEff_3.FormattingEnabled = True
+            Me.cbxStructProdBonus_TimEff_3.Location = New System.Drawing.Point(222, 90)
+            Me.cbxStructProdBonus_TimEff_3.Name = "cbxStructProdBonus_TimEff_3"
+            Me.cbxStructProdBonus_TimEff_3.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_TimEff_3.TabIndex = 10
+            '
+            'cbxStructProdBonus_TimEff_2
+            '
+            Me.cbxStructProdBonus_TimEff_2.Enabled = False
+            Me.cbxStructProdBonus_TimEff_2.FormattingEnabled = True
+            Me.cbxStructProdBonus_TimEff_2.Location = New System.Drawing.Point(222, 65)
+            Me.cbxStructProdBonus_TimEff_2.Name = "cbxStructProdBonus_TimEff_2"
+            Me.cbxStructProdBonus_TimEff_2.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_TimEff_2.TabIndex = 9
+            '
+            'cbxStructProdBonus_TimEff_1
+            '
+            Me.cbxStructProdBonus_TimEff_1.Enabled = False
+            Me.cbxStructProdBonus_TimEff_1.FormattingEnabled = True
+            Me.cbxStructProdBonus_TimEff_1.Location = New System.Drawing.Point(222, 38)
+            Me.cbxStructProdBonus_TimEff_1.Name = "cbxStructProdBonus_TimEff_1"
+            Me.cbxStructProdBonus_TimEff_1.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_TimEff_1.TabIndex = 8
+            '
+            'cbxStructProdBonus_MatEff_3
+            '
+            Me.cbxStructProdBonus_MatEff_3.Enabled = False
+            Me.cbxStructProdBonus_MatEff_3.FormattingEnabled = True
+            Me.cbxStructProdBonus_MatEff_3.Location = New System.Drawing.Point(160, 90)
+            Me.cbxStructProdBonus_MatEff_3.Name = "cbxStructProdBonus_MatEff_3"
+            Me.cbxStructProdBonus_MatEff_3.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_MatEff_3.TabIndex = 7
+            '
+            'cbxStructProdBonus_MatEff_2
+            '
+            Me.cbxStructProdBonus_MatEff_2.Enabled = False
+            Me.cbxStructProdBonus_MatEff_2.FormattingEnabled = True
+            Me.cbxStructProdBonus_MatEff_2.Location = New System.Drawing.Point(160, 65)
+            Me.cbxStructProdBonus_MatEff_2.Name = "cbxStructProdBonus_MatEff_2"
+            Me.cbxStructProdBonus_MatEff_2.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_MatEff_2.TabIndex = 6
+            '
+            'cbxStructProdBonus_MatEff_1
+            '
+            Me.cbxStructProdBonus_MatEff_1.Enabled = False
+            Me.cbxStructProdBonus_MatEff_1.FormattingEnabled = True
+            Me.cbxStructProdBonus_MatEff_1.Location = New System.Drawing.Point(160, 38)
+            Me.cbxStructProdBonus_MatEff_1.Name = "cbxStructProdBonus_MatEff_1"
+            Me.cbxStructProdBonus_MatEff_1.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructProdBonus_MatEff_1.TabIndex = 5
+            '
+            'cbxStructProdBonus_Group_3
+            '
+            Me.cbxStructProdBonus_Group_3.Enabled = False
+            Me.cbxStructProdBonus_Group_3.FormattingEnabled = True
+            Me.cbxStructProdBonus_Group_3.Location = New System.Drawing.Point(6, 90)
+            Me.cbxStructProdBonus_Group_3.Name = "cbxStructProdBonus_Group_3"
+            Me.cbxStructProdBonus_Group_3.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructProdBonus_Group_3.TabIndex = 4
+            '
+            'lblItemGroup
+            '
+            Me.lblItemGroup.AutoSize = True
+            Me.lblItemGroup.Location = New System.Drawing.Point(3, 18)
+            Me.lblItemGroup.Name = "lblItemGroup"
+            Me.lblItemGroup.Size = New System.Drawing.Size(64, 13)
+            Me.lblItemGroup.TabIndex = 3
+            Me.lblItemGroup.Text = "Items Group"
+            '
+            'cbxStructProdBonus_Group_2
+            '
+            Me.cbxStructProdBonus_Group_2.Enabled = False
+            Me.cbxStructProdBonus_Group_2.FormattingEnabled = True
+            Me.cbxStructProdBonus_Group_2.Location = New System.Drawing.Point(6, 65)
+            Me.cbxStructProdBonus_Group_2.Name = "cbxStructProdBonus_Group_2"
+            Me.cbxStructProdBonus_Group_2.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructProdBonus_Group_2.TabIndex = 1
+            '
+            'cbxStructProdBonus_Group_1
+            '
+            Me.cbxStructProdBonus_Group_1.Enabled = False
+            Me.cbxStructProdBonus_Group_1.FormattingEnabled = True
+            Me.cbxStructProdBonus_Group_1.Location = New System.Drawing.Point(6, 38)
+            Me.cbxStructProdBonus_Group_1.Name = "cbxStructProdBonus_Group_1"
+            Me.cbxStructProdBonus_Group_1.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructProdBonus_Group_1.TabIndex = 0
+            '
+            'gpxStructScienceBonuses
+            '
+            Me.gpxStructScienceBonuses.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) _
+            Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.lblStructScieBonus_TimEff)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_Group_1)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.lblStructScieBonus_CosEff)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_Group_2)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_TimEff_3)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.lblScienceJobType)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_TimEff_2)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_Group_3)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_TimEff_1)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_CosEff_1)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_CosEff_3)
+            Me.gpxStructScienceBonuses.Controls.Add(Me.cbxStructScieBonus_CosEff_2)
+            Me.gpxStructScienceBonuses.Location = New System.Drawing.Point(12, 223)
+            Me.gpxStructScienceBonuses.Name = "gpxStructScienceBonuses"
+            Me.gpxStructScienceBonuses.Size = New System.Drawing.Size(290, 121)
+            Me.gpxStructScienceBonuses.TabIndex = 2
+            Me.gpxStructScienceBonuses.TabStop = False
+            Me.gpxStructScienceBonuses.Text = "Science Jobs Bonuses from Rigs"
+            '
+            'lblStructScieBonus_TimEff
+            '
+            Me.lblStructScieBonus_TimEff.AutoSize = True
+            Me.lblStructScieBonus_TimEff.Location = New System.Drawing.Point(219, 19)
+            Me.lblStructScieBonus_TimEff.Name = "lblStructScieBonus_TimEff"
+            Me.lblStructScieBonus_TimEff.Size = New System.Drawing.Size(54, 13)
+            Me.lblStructScieBonus_TimEff.TabIndex = 11
+            Me.lblStructScieBonus_TimEff.Text = "TE Bonus"
+            '
+            'cbxStructScieBonus_Group_1
+            '
+            Me.cbxStructScieBonus_Group_1.Enabled = False
+            Me.cbxStructScieBonus_Group_1.FormattingEnabled = True
+            Me.cbxStructScieBonus_Group_1.Location = New System.Drawing.Point(6, 39)
+            Me.cbxStructScieBonus_Group_1.Name = "cbxStructScieBonus_Group_1"
+            Me.cbxStructScieBonus_Group_1.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructScieBonus_Group_1.TabIndex = 13
+            '
+            'lblStructScieBonus_CosEff
+            '
+            Me.lblStructScieBonus_CosEff.AutoSize = True
+            Me.lblStructScieBonus_CosEff.Location = New System.Drawing.Point(157, 19)
+            Me.lblStructScieBonus_CosEff.Name = "lblStructScieBonus_CosEff"
+            Me.lblStructScieBonus_CosEff.Size = New System.Drawing.Size(54, 13)
+            Me.lblStructScieBonus_CosEff.TabIndex = 12
+            Me.lblStructScieBonus_CosEff.Text = "CE Bonus"
+            '
+            'cbxStructScieBonus_Group_2
+            '
+            Me.cbxStructScieBonus_Group_2.Enabled = False
+            Me.cbxStructScieBonus_Group_2.FormattingEnabled = True
+            Me.cbxStructScieBonus_Group_2.Location = New System.Drawing.Point(6, 66)
+            Me.cbxStructScieBonus_Group_2.Name = "cbxStructScieBonus_Group_2"
+            Me.cbxStructScieBonus_Group_2.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructScieBonus_Group_2.TabIndex = 14
+            '
+            'cbxStructScieBonus_TimEff_3
+            '
+            Me.cbxStructScieBonus_TimEff_3.Enabled = False
+            Me.cbxStructScieBonus_TimEff_3.FormattingEnabled = True
+            Me.cbxStructScieBonus_TimEff_3.Location = New System.Drawing.Point(222, 91)
+            Me.cbxStructScieBonus_TimEff_3.Name = "cbxStructScieBonus_TimEff_3"
+            Me.cbxStructScieBonus_TimEff_3.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_TimEff_3.TabIndex = 22
+            '
+            'lblScienceJobType
+            '
+            Me.lblScienceJobType.AutoSize = True
+            Me.lblScienceJobType.Location = New System.Drawing.Point(3, 19)
+            Me.lblScienceJobType.Name = "lblScienceJobType"
+            Me.lblScienceJobType.Size = New System.Drawing.Size(98, 13)
+            Me.lblScienceJobType.TabIndex = 15
+            Me.lblScienceJobType.Text = "Science Jobs Type"
+            '
+            'cbxStructScieBonus_TimEff_2
+            '
+            Me.cbxStructScieBonus_TimEff_2.Enabled = False
+            Me.cbxStructScieBonus_TimEff_2.FormattingEnabled = True
+            Me.cbxStructScieBonus_TimEff_2.Location = New System.Drawing.Point(222, 66)
+            Me.cbxStructScieBonus_TimEff_2.Name = "cbxStructScieBonus_TimEff_2"
+            Me.cbxStructScieBonus_TimEff_2.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_TimEff_2.TabIndex = 21
+            '
+            'cbxStructScieBonus_Group_3
+            '
+            Me.cbxStructScieBonus_Group_3.Enabled = False
+            Me.cbxStructScieBonus_Group_3.FormattingEnabled = True
+            Me.cbxStructScieBonus_Group_3.Location = New System.Drawing.Point(6, 91)
+            Me.cbxStructScieBonus_Group_3.Name = "cbxStructScieBonus_Group_3"
+            Me.cbxStructScieBonus_Group_3.Size = New System.Drawing.Size(148, 21)
+            Me.cbxStructScieBonus_Group_3.TabIndex = 16
+            '
+            'cbxStructScieBonus_TimEff_1
+            '
+            Me.cbxStructScieBonus_TimEff_1.Enabled = False
+            Me.cbxStructScieBonus_TimEff_1.FormattingEnabled = True
+            Me.cbxStructScieBonus_TimEff_1.Location = New System.Drawing.Point(222, 39)
+            Me.cbxStructScieBonus_TimEff_1.Name = "cbxStructScieBonus_TimEff_1"
+            Me.cbxStructScieBonus_TimEff_1.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_TimEff_1.TabIndex = 20
+            '
+            'cbxStructScieBonus_CosEff_1
+            '
+            Me.cbxStructScieBonus_CosEff_1.Enabled = False
+            Me.cbxStructScieBonus_CosEff_1.FormattingEnabled = True
+            Me.cbxStructScieBonus_CosEff_1.Location = New System.Drawing.Point(160, 39)
+            Me.cbxStructScieBonus_CosEff_1.Name = "cbxStructScieBonus_CosEff_1"
+            Me.cbxStructScieBonus_CosEff_1.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_CosEff_1.TabIndex = 17
+            '
+            'cbxStructScieBonus_CosEff_3
+            '
+            Me.cbxStructScieBonus_CosEff_3.Enabled = False
+            Me.cbxStructScieBonus_CosEff_3.FormattingEnabled = True
+            Me.cbxStructScieBonus_CosEff_3.Location = New System.Drawing.Point(160, 91)
+            Me.cbxStructScieBonus_CosEff_3.Name = "cbxStructScieBonus_CosEff_3"
+            Me.cbxStructScieBonus_CosEff_3.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_CosEff_3.TabIndex = 19
+            '
+            'cbxStructScieBonus_CosEff_2
+            '
+            Me.cbxStructScieBonus_CosEff_2.Enabled = False
+            Me.cbxStructScieBonus_CosEff_2.FormattingEnabled = True
+            Me.cbxStructScieBonus_CosEff_2.Location = New System.Drawing.Point(160, 66)
+            Me.cbxStructScieBonus_CosEff_2.Name = "cbxStructScieBonus_CosEff_2"
+            Me.cbxStructScieBonus_CosEff_2.Size = New System.Drawing.Size(56, 21)
+            Me.cbxStructScieBonus_CosEff_2.TabIndex = 18
+            '
+            'btnCancel
+            '
+            Me.btnCancel.Location = New System.Drawing.Point(227, 350)
+            Me.btnCancel.Name = "btnCancel"
+            Me.btnCancel.Size = New System.Drawing.Size(75, 23)
+            Me.btnCancel.TabIndex = 3
+            Me.btnCancel.Text = "Cancel"
+            Me.btnCancel.UseVisualStyleBackColor = True
+            '
+            'btnSave
+            '
+            Me.btnSave.Location = New System.Drawing.Point(146, 350)
+            Me.btnSave.Name = "btnSave"
+            Me.btnSave.Size = New System.Drawing.Size(75, 23)
+            Me.btnSave.TabIndex = 4
+            Me.btnSave.Text = "Save"
+            Me.btnSave.UseVisualStyleBackColor = True
+            '
+            'frmFavoriteStructure
+            '
+            Me.AutoScaleDimensions = New System.Drawing.SizeF(6.0!, 13.0!)
+            Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+            Me.ClientSize = New System.Drawing.Size(314, 379)
+            Me.Controls.Add(Me.btnSave)
+            Me.Controls.Add(Me.btnCancel)
+            Me.Controls.Add(Me.gpxStructScienceBonuses)
+            Me.Controls.Add(Me.gpxStructProdBonuses)
+            Me.Controls.Add(Me.pnlStructDefinition)
+            Me.Name = "frmFavoriteStructure"
+            Me.Text = "Favorite Structure"
+            Me.pnlStructDefinition.ResumeLayout(False)
+            Me.pnlStructDefinition.PerformLayout()
+            Me.gpxStructProdBonuses.ResumeLayout(False)
+            Me.gpxStructProdBonuses.PerformLayout()
+            Me.gpxStructScienceBonuses.ResumeLayout(False)
+            Me.gpxStructScienceBonuses.PerformLayout()
+            Me.ResumeLayout(False)
+
+        End Sub
+
+        Friend WithEvents pnlStructDefinition As Windows.Forms.Panel
+        Friend WithEvents cbxStructLocation As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructType As Windows.Forms.ComboBox
+        Friend WithEvents tfStructName As Windows.Forms.TextBox
+        Friend WithEvents lblStructLocation As Windows.Forms.Label
+        Friend WithEvents lblStructType As Windows.Forms.Label
+        Friend WithEvents lblStructName As Windows.Forms.Label
+        Friend WithEvents gpxStructProdBonuses As Windows.Forms.GroupBox
+        Friend WithEvents gpxStructScienceBonuses As Windows.Forms.GroupBox
+        Friend WithEvents cbxStructProdBonus_MatEff_1 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_Group_3 As Windows.Forms.ComboBox
+        Friend WithEvents lblItemGroup As Windows.Forms.Label
+        Friend WithEvents cbxStructProdBonus_Group_2 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_Group_1 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_TimEff_3 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_TimEff_2 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_TimEff_1 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_MatEff_3 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructProdBonus_MatEff_2 As Windows.Forms.ComboBox
+        Friend WithEvents lblStructProdBonus_TimEff As Windows.Forms.Label
+        Friend WithEvents lblStructProdBonus_MatEff As Windows.Forms.Label
+        Friend WithEvents lblStructScieBonus_TimEff As Windows.Forms.Label
+        Friend WithEvents cbxStructScieBonus_Group_1 As Windows.Forms.ComboBox
+        Friend WithEvents lblStructScieBonus_CosEff As Windows.Forms.Label
+        Friend WithEvents cbxStructScieBonus_Group_2 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_TimEff_3 As Windows.Forms.ComboBox
+        Friend WithEvents lblScienceJobType As Windows.Forms.Label
+        Friend WithEvents cbxStructScieBonus_TimEff_2 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_Group_3 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_TimEff_1 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_CosEff_1 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_CosEff_3 As Windows.Forms.ComboBox
+        Friend WithEvents cbxStructScieBonus_CosEff_2 As Windows.Forms.ComboBox
+        Friend WithEvents btnCancel As Windows.Forms.Button
+        Friend WithEvents btnSave As Windows.Forms.Button
+    End Class
+
+End Namespace

--- a/EveHQ.Prism/Forms/frmUpwellStructure.resx
+++ b/EveHQ.Prism/Forms/frmUpwellStructure.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/EveHQ.Prism/Forms/frmUpwellStructure.vb
+++ b/EveHQ.Prism/Forms/frmUpwellStructure.vb
@@ -1,0 +1,278 @@
+﻿Imports System.Windows.Forms
+Imports EveHQ.EveData
+
+Namespace Global.EveHQ.Plugins.Prism.UpwellStructures
+
+    Public Class frmUpwellStructure
+
+        Private _FavoriteStructure As UpwellStructure
+
+        ''' <summary>
+        ''' Init a Structure Preference Window with empty structure
+        ''' </summary>
+        Public Sub New()
+
+            Me.New(New UpwellStructure())
+
+        End Sub
+
+        ''' <summary>
+        ''' Init a Structure Preference Window
+        ''' </summary>
+        ''' <param name="structPref">The Structure to which preference should be attached</param>
+        Public Sub New(structPref As UpwellStructure)
+
+            InitializeComponent()
+
+            Me._FavoriteStructure = structPref
+
+            ' Debug
+            Me._FavoriteStructure.Location = StaticData.SolarSystems(30000142)
+            Me._FavoriteStructure.ItemType = StaticData.Types(35827)
+
+            ' Bind Structure Name
+            Me.tfStructName.DataBindings.Add("Text", Me._FavoriteStructure, "Name", False, DataSourceUpdateMode.OnPropertyChanged)
+
+            ' Init and Bing Structure Type
+            Me.cbxStructType.DataSource = Me.GetPossibleTypes()
+            Me.cbxStructType.DisplayMember = "Name"
+            Me.cbxStructType.DataBindings.Add("SelectedItem", Me._FavoriteStructure, "ItemType")
+
+            ' Init and Bind Location List
+            Me.cbxStructLocation.DataSource = Me.GetPossibleLocations()
+            Me.cbxStructLocation.DisplayMember = "Name"
+            Me.cbxStructLocation.DataBindings.Add("SelectedItem", Me._FavoriteStructure, "Location")
+
+            ' Init Bonus Binding
+            Me.cbxStructProdBonus_Group_1.DisplayMember = "Name"
+            Me.cbxStructProdBonus_Group_2.DisplayMember = "Name"
+            Me.cbxStructProdBonus_Group_3.DisplayMember = "Name"
+
+            Me.cbxStructScieBonus_Group_1.DisplayMember = "Name"
+            Me.cbxStructScieBonus_Group_2.DisplayMember = "Name"
+            Me.cbxStructScieBonus_Group_3.DisplayMember = "Name"
+
+            CheckMandatoryFields()
+
+        End Sub
+
+        Private Sub btnCancel_Click(sender As Object, e As EventArgs) Handles btnCancel.Click
+
+            Me.Close()
+
+        End Sub
+
+        ''' <summary>
+        ''' A list of possible EveType for Structure Type
+        ''' </summary>
+        ''' <returns></returns>
+        Private Function GetPossibleTypes() As List(Of EveType)
+
+            Dim possibleTypes = From type In StaticData.Types().Values
+                                Where type.Category = 65 ' Structures
+                                Where type.Published = True
+                                Order By type.Name
+
+            Return possibleTypes.ToList()
+
+        End Function
+
+        ''' <summary>
+        ''' A list of possible SolarSystems for Structure Location
+        ''' </summary>
+        ''' <returns></returns>
+        Private Function GetPossibleLocations() As List(Of SolarSystem)
+
+            Dim possibleLocations = From solarSystem In StaticData.SolarSystems.Values
+                                    Order By solarSystem.Name
+                                    Select solarSystem
+
+            Return possibleLocations.ToList()
+
+        End Function
+
+        Private Function GetPossibleBonuses() As List(Of Bonus)
+
+            ' Fetch RigSize attribute related to the current structure in order to determine which set should be load
+            Dim rigSize As Double = (From attribute In StaticData.GetAttributeDataForItem(Me._FavoriteStructure.ItemType.Id).Values
+                                     Where attribute.Id = 1547
+                                     Select attribute.Value).FirstOrDefault()
+
+            Select Case rigSize
+                Case 2
+                    Return Me.GetMediumBonusSets()
+                Case 3
+                    Return Me.GetLargeBonusSets()
+                Case 4
+                    Return Me.GetXLargeBonusSets()
+            End Select
+
+            Return New List(Of Bonus)
+
+        End Function
+
+        Private Function GetMediumBonusSets() As List(Of Bonus)
+
+            Dim bonusSets As List(Of Bonus) = New List(Of Bonus)
+
+            Dim bonus As Bonus = New Bonus("Ammunition, Charges, Scripts (T1)", 0.02D, 0.2D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToCharges())
+
+            bonus = New Bonus("Ammunition, Charges, Scripts (T2)", 0.02D, 0.24D, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToCharges())
+
+            bonus = New Bonus("Drones, Fighters (T1)", 0.02D, 0.2D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToDrones())
+
+            bonus = New Bonus("Drones, Fighters (T2)", 0.024D, 0.24D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToDrones())
+
+            bonus = New Bonus("Frigates, Destroyers, Shuttles (T1)", 0.02D, 0.2D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToT1SmallShips())
+
+            bonus = New Bonus("Frigates, Destroyers, Shuttles (T2)", 0.024D, 0.24D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToT1SmallShips())
+
+            bonus = New Bonus("Cruisers, Battlecruisers, Industrial Ships, Mining Barges (T1)", 0.02D, 0.2D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToT1MediumShips())
+
+            bonus = New Bonus("Cruisers, Battlecruisers, Industrial Ships, Mining Barges (T2)", 0.024D, 0.24D, 0, JobType.Manufacturing)
+            ' ME
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.MaterialEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+            ' TE
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Low, 1.9D)
+            bonus.TimeEfficiencyModificators.Add(SolarSystemSecurityRange.Null, 2.1D)
+
+            bonusSets.Add(bonus.ApplyToT1MediumShips())
+
+            Return bonusSets
+
+        End Function
+
+        Private Function GetLargeBonusSets() As List(Of Bonus)
+
+            Dim bonusSets As List(Of Bonus) = New List(Of Bonus)
+
+            Return bonusSets
+
+        End Function
+
+        Private Function GetXLargeBonusSets() As List(Of Bonus)
+
+            Dim bonusSets As List(Of Bonus) = New List(Of Bonus)
+
+            Return bonusSets
+
+        End Function
+
+        ''' <summary>
+        ''' Ensure that all required field are filled before enabling bonus grids
+        ''' </summary>
+        Private Sub CheckMandatoryFields()
+
+            Me.cbxStructProdBonus_Group_1.Enabled = False
+            Me.cbxStructProdBonus_Group_2.Enabled = False
+            Me.cbxStructProdBonus_Group_3.Enabled = False
+
+            Me.cbxStructScieBonus_Group_1.Enabled = False
+            Me.cbxStructScieBonus_Group_2.Enabled = False
+            Me.cbxStructScieBonus_Group_3.Enabled = False
+
+            If Not String.IsNullOrEmpty(Me._FavoriteStructure.Name) And Me._FavoriteStructure.Location IsNot Nothing And Me._FavoriteStructure.ItemType IsNot Nothing Then
+
+                Me.cbxStructProdBonus_Group_1.Enabled = True
+                Me.cbxStructProdBonus_Group_2.Enabled = True
+                Me.cbxStructProdBonus_Group_3.Enabled = True
+
+                Me.cbxStructScieBonus_Group_1.Enabled = True
+                Me.cbxStructScieBonus_Group_2.Enabled = True
+                Me.cbxStructScieBonus_Group_3.Enabled = True
+
+            End If
+
+            Me.Update()
+
+        End Sub
+
+        Private Sub tfStructName_Validated(sender As Object, e As EventArgs) Handles tfStructName.Validated
+
+            Me.CheckMandatoryFields()
+
+        End Sub
+
+        Private Sub cbxStructType_Validated(sender As Object, e As EventArgs) Handles cbxStructType.Validated
+
+            If Me._FavoriteStructure.Location IsNot Nothing Then
+
+                Me.cbxStructProdBonus_Group_1.DataSource = Me.GetPossibleBonuses()
+                Me.cbxStructProdBonus_Group_2.DataSource = Me.GetPossibleBonuses()
+                Me.cbxStructProdBonus_Group_3.DataSource = Me.GetPossibleBonuses()
+
+            End If
+
+        End Sub
+
+        Private Sub cbxStructLocation_Validated(sender As Object, e As EventArgs) Handles cbxStructLocation.Validated
+
+            If Me._FavoriteStructure.ItemType IsNot Nothing Then
+
+                Me.cbxStructProdBonus_Group_1.DataSource = Me.GetPossibleBonuses()
+                Me.cbxStructProdBonus_Group_2.DataSource = Me.GetPossibleBonuses()
+                Me.cbxStructProdBonus_Group_3.DataSource = Me.GetPossibleBonuses()
+
+            End If
+
+        End Sub
+    End Class
+
+End Namespace


### PR DESCRIPTION
I would have a feedback on the way I'm currently handling the new feature for Prism and its BP calculator.

I'm attempting to have as much possible a cleaner form (`frmStructurePreference.vb`) in order to avoid useless methods and event handlers.
Todo so, I'm using databinding which are binding form fields to model properties (`StructurePreference.vb`)

The `StructurePreference.vb` model is storing a list of bonus model (`StructureBonus.vb`) with bonuses which are applied by the structure.

Then, when you're simulating an industry job from BP Calculator which is either a manufacturing or a science job, we just need to iterate over bonuses and call `IsAppliedTo()` method.
This method will return true if the bonus from which it is called is applying to the passed item.